### PR TITLE
Fix: Resolve TypeError in Leaflet Routing Machine

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,10 @@
             cursor: pointer !important;
         }
 
+        .leaflet-routing-container {
+            display: none !important;
+        }
+
         #sidebar {
             width: 320px;
             background: #0d1117;
@@ -549,7 +553,7 @@
                     {color: 'yellow', opacity: 0.7, weight: 6, dashArray: '10, 10'}
                 ]
             }
-        }); // Do NOT call .addTo(map) here if we want it to be hidden initially,
+        }).addTo(map);
             // as the line should be drawn by the routing machine plugin itself.
 
         // To effectively hide the control's UI if it were added to the map:


### PR DESCRIPTION
The Leaflet Routing Machine was throwing a "TypeError: Cannot read properties of undefined (reading 'appendChild')" because the control was initialized but not added to the map. This prevented its internal DOM setup from completing correctly.

This commit addresses the issue by:
1. Modifying the `L.Routing.control` initialization to chain `.addTo(map)`. This ensures the control is properly registered with Leaflet and can manage its DOM elements. The `show: false` option within the control's configuration is intended to keep it visually hidden.
2. Adding an explicit CSS rule (`.leaflet-routing-container { display: none !important; }`) as a safeguard to ensure no part of the routing control's UI becomes visible, maintaining the original design intent of a programmatic-only routing control.